### PR TITLE
Add unicode support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,6 +29,12 @@ pub fn build(b: *std.Build) void {
     module.addOptions("build_options", module_options);
     lib_unit_tests.root_module.addOptions("build_options", module_options);
 
+    const zg = b.dependency("zg", .{});
+    module.addImport("grapheme", zg.module("grapheme"));
+    module.addImport("DisplayWidth", zg.module("DisplayWidth"));
+    lib_unit_tests.root_module.addImport("grapheme", zg.module("grapheme"));
+    lib_unit_tests.root_module.addImport("DisplayWidth", zg.module("DisplayWidth"));
+
     switch (user_options.backend) {
         .ncurses => {
             module.link_libc = true;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -38,6 +38,10 @@
             .url = "https://github.com/akarpovskii/tuile-crossterm/releases/download/v0.1.1/libtuile_crossterm-x86_64-unknown-linux-gnu.tar.gz",
             .hash = "12203b342eb4f61aa0e03a95dffd3ae14e31ea1200285ac8e23b813aa6b80faf0243",
         },
+        .zg = .{
+            .url = "https://codeberg.org/dude_the_builder/zg/archive/c425c9c8511bf92e14b8b612d1d16e774b186f2e.tar.gz",
+            .hash = "1220c79009f1e443b015db4de6e5319432538ead2fea10d271f3f35d3ae83c996789",
+        },
     },
     .minimum_zig_version = "0.12.0",
     .paths = .{

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -21,6 +21,7 @@ pub fn build(b: *std.Build) void {
         "fps_counter",
         "event_handler",
         "palette",
+        "unicode",
     };
     inline for (executables) |name| {
         const exe = b.addExecutable(.{

--- a/examples/src/unicode.zig
+++ b/examples/src/unicode.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const tuile = @import("tuile");
+
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+pub const tuile_allocator = gpa.allocator();
+
+const UserInputState = struct {
+    tui: *tuile.Tuile,
+
+    pub fn inputChanged(self_opt: ?*UserInputState, value: []const u8) void {
+        const self = self_opt.?;
+        if (value.len > 0) {
+            const label = self.tui.findByIdTyped(tuile.Label, "unicode-table") orelse unreachable;
+            const start = std.fmt.parseInt(u21, value, 16) catch {
+                label.setText("Invalid hex code") catch unreachable;
+                return;
+            };
+
+            const txt = generateUnicodeTable(start);
+            label.setText(txt) catch unreachable;
+            tuile_allocator.free(txt);
+        }
+    }
+
+    fn generateUnicodeTable(start: u21) []const u8 {
+        var string = std.ArrayListUnmanaged(u8){};
+        const w = 32;
+        const h = 32;
+        for (0..h) |y| {
+            for (0..w) |x| {
+                const character: u21 = @intCast(start + y * w + x);
+                var cp = std.mem.zeroes([4]u8);
+                const len = std.unicode.utf8Encode(character, &cp) catch @panic("Incorrect unicode");
+                string.appendSlice(tuile_allocator, cp[0..len]) catch @panic("OOM");
+            }
+            string.append(tuile_allocator, '\n') catch @panic("OOM");
+        }
+        return string.toOwnedSlice(tuile_allocator) catch @panic("OOM");
+    }
+};
+
+pub fn main() !void {
+    var tui = try tuile.Tuile.init(.{});
+    defer tui.deinit();
+
+    var input_state = UserInputState{ .tui = &tui };
+
+    const layout = tuile.vertical(
+        .{ .layout = .{ .flex = 1 } },
+        .{
+            tuile.block(
+                .{ .border = tuile.border.Border.all(), .layout = .{ .flex = 1 } },
+                tuile.label(.{ .id = "unicode-table", .text = "" }),
+            ),
+
+            tuile.horizontal(
+                .{},
+                .{
+                    tuile.label(.{ .text = "Starting unicode value: U+" }), tuile.input(.{
+                        .id = "user-input",
+                        .layout = .{ .flex = 1 },
+                        .on_value_changed = .{
+                            .cb = @ptrCast(&UserInputState.inputChanged),
+                            .payload = &input_state,
+                        },
+                    }),
+                },
+            ),
+        },
+    );
+
+    try tui.add(layout);
+
+    const input = tui.findByIdTyped(tuile.Input, "user-input") orelse unreachable;
+    try input.setValue("1F300");
+    UserInputState.inputChanged(&input_state, "1F300");
+
+    try tui.run();
+}

--- a/examples/src/unicode.zig
+++ b/examples/src/unicode.zig
@@ -108,9 +108,6 @@ pub fn main() !void {
                 .{},
                 .{
                     tuile.label(.{ .text = "Unicode bytes (hex): " }),
-                    // \xf0\x9f\x91\xa9\xf0\x9f\x8f\xbd
-                    tuile.label(.{ .text = "\xf0\x9f\x91\xa9" }),
-                    tuile.label(.{ .text = "\xf0\x9f\x8f\xbd" }),
                     tuile.input(.{
                         .id = "bytes-input",
                         .layout = .{ .flex = 1 },

--- a/src/backends/Crossterm.zig
+++ b/src/backends/Crossterm.zig
@@ -187,8 +187,7 @@ fn convertEvent(rust_key: RustKey) ?events.Event {
         .None => return null,
         .Char => blk: {
             const char: u32 = @bitCast(rust_key.code);
-            // TODO: support UTF-8 input
-            break :blk events.Event{ .char = @truncate(char) };
+            break :blk events.Event{ .char = @intCast(char) };
         },
         .Enter => events.Event{ .key = .Enter },
         .Escape => events.Event{ .key = .Escape },

--- a/src/backends/Ncurses.zig
+++ b/src/backends/Ncurses.zig
@@ -85,7 +85,14 @@ pub fn pollEvent(_: *Ncurses) !?events.Event {
         else => {},
     }
 
-    return .{ .char = @intCast(ch) };
+    var cp = std.mem.zeroes([4]u8);
+    cp[0] = @intCast(ch);
+    var i: usize = 1;
+    while (!std.unicode.utf8ValidateSlice(&cp) and i < 4) {
+        cp[i] = @intCast(c.getch());
+        i += 1;
+    }
+    return .{ .char = try std.unicode.utf8Decode(cp[0..i]) };
 }
 
 fn parseKey(ch: c_int) ?events.Key {

--- a/src/events.zig
+++ b/src/events.zig
@@ -32,9 +32,9 @@ pub const Key = enum {
 pub const FocusDirection = enum { front, back };
 
 pub const Event = union(enum) {
-    char: u8,
+    char: u21,
     key: Key,
-    ctrl_char: u8,
+    ctrl_char: u21,
     shift_key: Key,
 
     focus_in: FocusDirection,

--- a/src/internal.zig
+++ b/src/internal.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const root = @import("root");
+const grapheme = @import("grapheme");
+const DisplayWidth = @import("DisplayWidth");
 
 const default_allocator = blk: {
     if (@hasDecl(root, "tuile_allocator")) {
@@ -15,3 +17,16 @@ const default_allocator = blk: {
 };
 
 pub const allocator = default_allocator;
+
+pub var gd: grapheme.GraphemeData = undefined;
+pub var dwd: DisplayWidth.DisplayWidthData = undefined;
+
+pub fn init() !void {
+    gd = try grapheme.GraphemeData.init(allocator);
+    dwd = try DisplayWidth.DisplayWidthData.init(allocator);
+}
+
+pub fn deinit() void {
+    dwd.deinit();
+    gd.deinit();
+}

--- a/src/render/Frame.zig
+++ b/src/render/Frame.zig
@@ -100,7 +100,7 @@ pub fn render(self: Frame, backend: Backend) !void {
             if (cell.symbol) |symbol| {
                 try backend.printAt(pos, symbol);
                 const width = dw.strWidth(symbol);
-                overflow = width - 1;
+                overflow = width -| 1;
             } else {
                 if (overflow > 0) {
                     // Previous character occupies this column, do nothing

--- a/src/tuile.zig
+++ b/src/tuile.zig
@@ -9,6 +9,8 @@ pub const widgets = @import("widgets.zig");
 pub usingnamespace widgets;
 pub const display = @import("display.zig");
 pub usingnamespace display;
+const grapheme = @import("grapheme");
+const DisplayWidth = @import("DisplayWidth");
 
 const Task = widgets.Callback(void);
 
@@ -52,6 +54,7 @@ pub const Tuile = struct {
     task_queue_mutex: std.Thread.Mutex,
 
     pub fn init(config: Config) !Tuile {
+        try internal.init();
         var self = blk: {
             const backend = if (config.backend) |backend| backend else try backends.createBackend();
             errdefer backend.destroy();
@@ -82,6 +85,7 @@ pub const Tuile = struct {
         self.backend.destroy();
         self.frame_buffer.deinit(internal.allocator);
         self.root.destroy();
+        internal.deinit();
     }
 
     pub fn add(self: *Tuile, child: anytype) !void {

--- a/src/widgets/Input.zig
+++ b/src/widgets/Input.zig
@@ -85,8 +85,8 @@ pub fn setValue(self: *Input, value: []const u8) !void {
     self.value.deinit(internal.allocator);
     self.value = std.ArrayListUnmanaged(u8){};
     try self.value.appendSlice(internal.allocator, value);
-    self.rebuildGraphemes(0);
-    self.grapheme_cursor = self.graphemes.items.len - 1;
+    try self.rebuildGraphemes(0);
+    self.grapheme_cursor = @intCast(self.graphemes.items.len -| 1);
 }
 
 fn cursor(self: Input) usize {

--- a/src/widgets/Label.zig
+++ b/src/widgets/Label.zig
@@ -8,6 +8,7 @@ const Frame = @import("../render/Frame.zig");
 const LayoutProperties = @import("LayoutProperties.zig");
 const Constraints = @import("Constraints.zig");
 const display = @import("../display.zig");
+const DisplayWidth = @import("DisplayWidth");
 
 const PartialChunk = struct {
     orig: usize,
@@ -116,12 +117,13 @@ pub fn render(self: *Label, area: Rect, frame: Frame, _: display.Theme) !void {
 pub fn layout(self: *Label, constraints: Constraints) !Vec2 {
     try self.wrapText(constraints);
 
+    const dw = DisplayWidth{ .data = &internal.dwd };
     var max_len: usize = 0;
     for (self.rows.items) |row| {
         var len: usize = 0;
         for (row.chunks.items) |chunk| {
             const text = self.content.getTextForChunk(chunk.orig)[chunk.start..chunk.end];
-            len += try std.unicode.utf8CountCodepoints(text);
+            len += dw.strWidth(text);
         }
         max_len = @max(max_len, len);
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Feature
```

## Description
<!--- Short description of your changes -->
Add unicode support for labels and inputs.

The implementation splits strings into graphemes using [zg](https://codeberg.org/dude_the_builder/zg) and prints each grapheme in a separate cell.

This works fine with simple unicode strings and even some composite symbols like `é = e + U+0301`, but fails on some terminals with emojis comprised of multiple code points like 🧑‍🌾.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- If it's OS-specific (like a backend), include details of your testing environment -->
Tested on macOS with both crossterm and ncurses backends.