### PR TITLE
Query for mode 2027

### DIFF
--- a/examples/src/unicode.zig
+++ b/examples/src/unicode.zig
@@ -43,7 +43,7 @@ const UnicodeTable = struct {
 const UnicodeBytes = struct {
     tui: *tuile.Tuile,
 
-    pub fn inputChanged(self_opt: ?*UnicodeTable, value: []const u8) void {
+    pub fn inputChanged(self_opt: ?*UnicodeBytes, value: []const u8) void {
         const self = self_opt.?;
         if (value.len > 0) {
             const label = self.tui.findByIdTyped(tuile.Label, "unicode-bytes") orelse unreachable;
@@ -123,9 +123,17 @@ pub fn main() !void {
 
     try tui.add(layout);
 
-    const input = tui.findByIdTyped(tuile.Input, "start-input") orelse unreachable;
-    try input.setValue("1F300");
-    UnicodeTable.inputChanged(&unicode_table, "1F300");
+    {
+        const input = tui.findByIdTyped(tuile.Input, "start-input") orelse unreachable;
+        try input.setValue("1F300");
+        UnicodeTable.inputChanged(&unicode_table, "1F300");
+    }
+
+    {
+        const input = tui.findByIdTyped(tuile.Input, "bytes-input") orelse unreachable;
+        try input.setValue("0xF0 0x9F 0x91 0x8D 0xF0 0x9F 0x8F 0xBD");
+        UnicodeBytes.inputChanged(&unicode_bytes, "0xF0 0x9F 0x91 0x8D 0xF0 0x9F 0x8F 0xBD");
+    }
 
     try tui.run();
 }

--- a/src/backends/Crossterm.zig
+++ b/src/backends/Crossterm.zig
@@ -227,3 +227,7 @@ fn convertEvent(rust_key: RustKey) ?events.Event {
     }
     return char_or_key;
 }
+
+pub fn requestMode(_: *Crossterm, mode: u32) !Backend.ReportMode {
+    return Backend.requestModeTty(mode);
+}

--- a/src/backends/Ncurses.zig
+++ b/src/backends/Ncurses.zig
@@ -235,3 +235,7 @@ fn colorToInt(color: display.Color) c_short {
 
     return @intCast(res);
 }
+
+pub fn requestMode(_: *Ncurses, mode: u32) !Backend.ReportMode {
+    return Backend.requestModeTty(mode);
+}

--- a/src/backends/Testing.zig
+++ b/src/backends/Testing.zig
@@ -25,7 +25,6 @@ pub fn create(window_size: Vec2) !*Testing {
             .min = Vec2.zero(),
             .max = window_size,
         },
-        .grapheme_clustering = false,
     };
     frame.clear(display.color("black"), display.color("white"));
 

--- a/src/backends/Testing.zig
+++ b/src/backends/Testing.zig
@@ -25,6 +25,7 @@ pub fn create(window_size: Vec2) !*Testing {
             .min = Vec2.zero(),
             .max = window_size,
         },
+        .grapheme_clustering = false,
     };
     frame.clear(display.color("black"), display.color("white"));
 
@@ -80,4 +81,8 @@ pub fn write(self: *Testing, writer: anytype) !void {
         }
         try writer.writeByte('\n');
     }
+}
+
+pub fn requestMode(_: *Testing, _: u32) !Backend.ReportMode {
+    return .not_recognized;
 }

--- a/src/backends/tty.zig
+++ b/src/backends/tty.zig
@@ -1,0 +1,93 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+comptime {
+    if (builtin.os.tag) {
+        @compileError("tty is not supported on Windows");
+    }
+}
+
+const c = @cImport({
+    @cInclude("sys/select.h");
+});
+
+extern "c" fn select(
+    nfds: c_int,
+    readfds: [*c]c.fd_set,
+    writefds: [*c]c.fd_set,
+    errorfds: [*c]c.fd_set,
+    timeout: [*c]c.timeval,
+) c_int;
+
+const SelectError = error{Failure};
+
+fn selectReadTimeout(tty: std.fs.File, nanoseconds: u64) SelectError!bool {
+    // You are supposed to use c.FD_ZERO(&rd), but there's a bug - https://github.com/ziglang/zig/issues/10123
+    // Luckily std.mem.zeroes does exactly the same thing for extern structs
+    var rd: c.fd_set = std.mem.zeroes(c.fd_set);
+    c.FD_SET(tty.handle, &rd);
+
+    var tv: c.timeval = .{};
+    tv.tv_sec = 0;
+    tv.tv_usec = @intCast(nanoseconds / std.time.ns_per_us);
+
+    const ret = select(tty.handle + 1, &rd, null, null, &tv);
+    return switch (ret) {
+        -1 => error.Failure,
+        0 => false,
+        else => true,
+    };
+}
+
+pub const ReportMode = enum(u3) {
+    not_recognized = 0,
+    set = 1,
+    reset = 2,
+    permanently_set = 3,
+    permanently_reset = 4,
+};
+
+pub fn requestMode(allocator: std.mem.Allocator, mode: u32) !ReportMode {
+    const tty = try std.fs.cwd().openFile("/dev/tty", .{ .mode = .read_write });
+
+    // DECRQM: CSI ? Pd $ p - https://vt100.net/docs/vt510-rm/DECRQM.html
+    // DECRPM: CSI ? Pd; Ps $ y - https://vt100.net/docs/vt510-rm/DECRPM.html
+    const CSI = "\x1B[";
+
+    // Request mode
+    try std.fmt.format(tty.writer(), CSI ++ "?{d}$p", .{mode});
+
+    // Report mode
+    const mode_str_len = std.fmt.count("{d}", .{mode});
+    const buf = try allocator.alloc(u8, CSI.len + mode_str_len + 5);
+    defer allocator.free(buf);
+
+    const timeout_ns = 100 * std.time.ns_per_ms;
+
+    switch (builtin.os.tag) {
+        .macos => {
+            // Can't use poll here because macOS doesn't support polling from /dev/tty* files.
+            if (!try selectReadTimeout(tty, timeout_ns)) {
+                return .not_recognized;
+            }
+            const read_bytes = try tty.read(buf);
+            if (read_bytes != buf.len) {
+                return .not_recognized;
+            }
+        },
+        else => {
+            var poller = std.io.poll(allocator, enum { tty }, .{ .tty = tty });
+            defer poller.deinit();
+            if (!try poller.pollTimeout(timeout_ns)) {
+                return .not_recognized;
+            }
+            const fifo = poller.fifo(.tty);
+            if (fifo.readableLength() != buf.len) {
+                return .not_recognized;
+            }
+            std.mem.copyForwards(u8, buf, fifo.buf[0..buf.len]);
+        },
+    }
+    const ps = try std.fmt.charToDigit(buf[CSI.len + 1 + mode_str_len + 1], 10);
+    return try std.meta.intToEnum(ReportMode, ps);
+}

--- a/src/backends/tty.zig
+++ b/src/backends/tty.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 comptime {
-    if (builtin.os.tag) {
+    if (builtin.os.tag == .windows) {
         @compileError("tty is not supported on Windows");
     }
 }

--- a/src/display/Style.zig
+++ b/src/display/Style.zig
@@ -24,6 +24,18 @@ pub const Effect = struct {
     bold: bool = false,
     italic: bool = false,
 
+    pub fn all() Effect {
+        return Effect{
+            .highlight = true,
+            .underline = true,
+            .reverse = true,
+            .blink = true,
+            .dim = true,
+            .bold = true,
+            .italic = true,
+        };
+    }
+
     /// Enables the effects in `self` that are enabled in `other`.
     /// This is effectively a `self or other` operation.
     pub fn add(self: Effect, other: Effect) Effect {

--- a/src/internal.zig
+++ b/src/internal.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const root = @import("root");
 const grapheme = @import("grapheme");
 const DisplayWidth = @import("DisplayWidth");
+const text_clustering = @import("text_clustering.zig");
 
 const default_allocator = blk: {
     if (@hasDecl(root, "tuile_allocator")) {
@@ -20,10 +21,12 @@ pub const allocator = default_allocator;
 
 pub var gd: grapheme.GraphemeData = undefined;
 pub var dwd: DisplayWidth.DisplayWidthData = undefined;
+pub var text_clustering_type: text_clustering.ClusteringType = undefined;
 
-pub fn init() !void {
+pub fn init(clustering: text_clustering.ClusteringType) !void {
     gd = try grapheme.GraphemeData.init(allocator);
     dwd = try DisplayWidth.DisplayWidthData.init(allocator);
+    text_clustering_type = clustering;
 }
 
 pub fn deinit() void {

--- a/src/render/Frame.zig
+++ b/src/render/Frame.zig
@@ -85,6 +85,8 @@ pub fn render(self: Frame, backend: Backend) !void {
     var last_effect = display.Style.Effect{};
     var last_color: ?display.ColorPair = null;
 
+    try backend.disableEffect(display.Style.Effect.all());
+
     for (0..self.size.y) |y| {
         // For the characters taking more than 1 column like の
         var overflow: usize = 0;

--- a/src/render/Frame.zig
+++ b/src/render/Frame.zig
@@ -4,9 +4,8 @@ const Vec2 = @import("../Vec2.zig");
 const Rect = @import("../Rect.zig");
 const Backend = @import("../backends/Backend.zig");
 const display = @import("../display.zig");
-const grapheme = @import("grapheme");
-const DisplayWidth = @import("DisplayWidth");
 const internal = @import("../internal.zig");
+const text_clustering = @import("../text_clustering.zig");
 
 const Frame = @This();
 
@@ -64,31 +63,25 @@ pub fn setSymbol(self: Frame, pos: Vec2, symbol: []const u8) void {
 }
 
 // Decodes text as UTF-8, writes all code points separately and returns the number of 'characters' written
-// TODO: Use graphemes instead of code points!
 pub fn writeSymbols(self: Frame, start: Vec2, bytes: []const u8, max: ?usize) !usize {
-    var iter = grapheme.Iterator.init(bytes, &internal.gd);
-    const dw = DisplayWidth{ .data = &internal.dwd };
-
+    var iter = try text_clustering.ClusterIterator.init(internal.text_clustering_type, bytes);
     var limit = max orelse std.math.maxInt(usize);
     var written: usize = 0;
     var cursor = start;
-    while (iter.next()) |gc| {
-        const substr = gc.bytes(bytes);
-        const width = dw.strWidth(substr);
-        if (width > limit) {
+    while (iter.next()) |cluster| {
+        if (cluster.display_width > limit) {
             break;
         }
-        self.setSymbol(cursor, substr);
+        self.setSymbol(cursor, cluster.bytes(bytes));
 
-        cursor.x += @intCast(width);
-        limit -= @intCast(width);
-        written += @intCast(width);
+        cursor.x += @intCast(cluster.display_width);
+        limit -= @intCast(cluster.display_width);
+        written += @intCast(cluster.display_width);
     }
     return written;
 }
 
 pub fn render(self: Frame, backend: Backend) !void {
-    const dw = DisplayWidth{ .data = &internal.dwd };
     var last_effect = display.Style.Effect{};
     var last_color: ?display.ColorPair = null;
 
@@ -124,7 +117,7 @@ pub fn render(self: Frame, backend: Backend) !void {
 
             if (cell.symbol) |symbol| {
                 try backend.printAt(pos, symbol);
-                const width = dw.strWidth(symbol);
+                const width = try text_clustering.stringDisplayWidth(symbol, internal.text_clustering_type);
                 overflow = width -| 1;
             } else {
                 if (overflow > 0) {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6,6 +6,7 @@ comptime {
     _ = @import("widgets/callbacks.zig");
     _ = @import("display/span.zig");
     _ = @import("display/colors.zig");
+    _ = @import("text_clustering.zig");
 }
 
 test {

--- a/src/text_clustering.zig
+++ b/src/text_clustering.zig
@@ -118,32 +118,34 @@ pub fn stringDisplayWidth(bytes: []const u8, clustering: ClusteringType) !usize 
 }
 
 test "codepoints cluster iterator" {
-    try internal.init();
+    try internal.init(.codepoints);
     defer internal.deinit();
-    var iter = try ClusterIterator.init(.codepoints, "\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD");
+    const str = "\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD";
+    var iter = try ClusterIterator.init(.codepoints, str);
     const cp1 = iter.next();
     try std.testing.expect(cp1 != null);
-    try std.testing.expectEqualStrings(cp1.?.bytes, "\xF0\x9F\x91\x8D");
+    try std.testing.expectEqualStrings(cp1.?.bytes(str), "\xF0\x9F\x91\x8D");
 
     const cp2 = iter.next();
     try std.testing.expect(cp2 != null);
-    try std.testing.expectEqualStrings(cp2.?.bytes, "\xF0\x9F\x8F\xBD");
+    try std.testing.expectEqualStrings(cp2.?.bytes(str), "\xF0\x9F\x8F\xBD");
 }
 
 test "graphemes cluster iterator" {
-    try internal.init();
+    try internal.init(.codepoints);
     defer internal.deinit();
-    var iter = try ClusterIterator.init(.graphemes, "\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD");
+    const str = "\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD";
+    var iter = try ClusterIterator.init(.graphemes, str);
     const cp1 = iter.next();
     try std.testing.expect(cp1 != null);
-    try std.testing.expectEqualStrings(cp1.?.bytes, "\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD");
+    try std.testing.expectEqualStrings(cp1.?.bytes(str), str);
 
     const cp2 = iter.next();
     try std.testing.expect(cp2 == null);
 }
 
 test "string display width" {
-    try internal.init();
+    try internal.init(.codepoints);
     defer internal.deinit();
     try std.testing.expectEqual(4, try stringDisplayWidth("\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD", .codepoints));
     try std.testing.expectEqual(2, try stringDisplayWidth("\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD", .graphemes));

--- a/src/text_clustering.zig
+++ b/src/text_clustering.zig
@@ -1,0 +1,150 @@
+const std = @import("std");
+const grapheme = @import("grapheme");
+const DisplayWidth = @import("DisplayWidth");
+const internal = @import("internal.zig");
+
+pub const TextCluster = struct {
+    len: u8,
+    offset: usize,
+    display_width: usize,
+
+    pub fn bytes(self: TextCluster, src: []const u8) []const u8 {
+        return src[self.offset..][0..self.len];
+    }
+};
+
+pub const GraphemeClusterIterator = struct {
+    bytes: []const u8,
+    impl: grapheme.Iterator,
+    dw: DisplayWidth,
+
+    pub fn init(bytes: []const u8) !GraphemeClusterIterator {
+        // grapheme.Iterator doesn't validate the slice
+        // though at this point it should be valid?
+        if (!std.unicode.utf8ValidateSlice(bytes)) {
+            return error.InvalidUtf8;
+        }
+        return GraphemeClusterIterator{
+            .bytes = bytes,
+            .impl = grapheme.Iterator.init(bytes, &internal.gd),
+            .dw = DisplayWidth{ .data = &internal.dwd },
+        };
+    }
+
+    pub fn next(self: *GraphemeClusterIterator) ?TextCluster {
+        if (self.impl.next()) |gc| {
+            return TextCluster{
+                .len = gc.len,
+                .offset = gc.offset,
+                .display_width = self.dw.strWidth(gc.bytes(self.bytes)),
+            };
+        } else {
+            return null;
+        }
+    }
+};
+
+pub const CodepointClusterIterator = struct {
+    cp_iter: std.unicode.Utf8Iterator,
+
+    pub fn init(bytes: []const u8) !CodepointClusterIterator {
+        const view = try std.unicode.Utf8View.init(bytes);
+        return CodepointClusterIterator{
+            .cp_iter = view.iterator(),
+        };
+    }
+
+    pub fn next(self: *CodepointClusterIterator) ?TextCluster {
+        if (self.cp_iter.nextCodepointSlice()) |slice_const| {
+            var slice = slice_const;
+            const cp = std.unicode.utf8Decode(slice) catch @panic("string was checked when constructing the iterator");
+            const width: usize = @intCast(@max(0, internal.dwd.codePointWidth(cp)));
+
+            // Put the following zero-width codepoints in the same cluster
+            var next_slice = self.cp_iter.peek(1);
+            while (next_slice.len > 0) {
+                const next_cp = std.unicode.utf8Decode(next_slice) catch @panic("string was checked when constructing the iterator");
+                const next_width: usize = @intCast(@max(0, internal.dwd.codePointWidth(next_cp)));
+                if (next_width > 0) {
+                    break;
+                }
+                slice.len += next_slice.len;
+                self.cp_iter.i += next_slice.len;
+                next_slice = self.cp_iter.peek(1);
+            }
+
+            return TextCluster{
+                .len = @intCast(slice.len),
+                .offset = @intFromPtr(slice.ptr) - @intFromPtr(self.cp_iter.bytes.ptr),
+                .display_width = width,
+            };
+        } else {
+            return null;
+        }
+    }
+};
+
+pub const ClusteringType = enum {
+    graphemes,
+    codepoints,
+};
+
+pub const ClusterIterator = union(ClusteringType) {
+    graphemes: GraphemeClusterIterator,
+    codepoints: CodepointClusterIterator,
+
+    pub fn init(clustering: ClusteringType, bytes: []const u8) !ClusterIterator {
+        return switch (clustering) {
+            .graphemes => .{ .graphemes = try GraphemeClusterIterator.init(bytes) },
+            .codepoints => .{ .codepoints = try CodepointClusterIterator.init(bytes) },
+        };
+    }
+
+    pub fn next(self: *ClusterIterator) ?TextCluster {
+        return switch (self.*) {
+            .graphemes => |*iter| iter.next(),
+            .codepoints => |*iter| iter.next(),
+        };
+    }
+};
+
+pub fn stringDisplayWidth(bytes: []const u8, clustering: ClusteringType) !usize {
+    var width: usize = 0;
+    var iter = try ClusterIterator.init(clustering, bytes);
+    while (iter.next()) |cluster| {
+        width += cluster.display_width;
+    }
+    return width;
+}
+
+test "codepoints cluster iterator" {
+    try internal.init();
+    defer internal.deinit();
+    var iter = try ClusterIterator.init(.codepoints, "\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD");
+    const cp1 = iter.next();
+    try std.testing.expect(cp1 != null);
+    try std.testing.expectEqualStrings(cp1.?.bytes, "\xF0\x9F\x91\x8D");
+
+    const cp2 = iter.next();
+    try std.testing.expect(cp2 != null);
+    try std.testing.expectEqualStrings(cp2.?.bytes, "\xF0\x9F\x8F\xBD");
+}
+
+test "graphemes cluster iterator" {
+    try internal.init();
+    defer internal.deinit();
+    var iter = try ClusterIterator.init(.graphemes, "\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD");
+    const cp1 = iter.next();
+    try std.testing.expect(cp1 != null);
+    try std.testing.expectEqualStrings(cp1.?.bytes, "\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD");
+
+    const cp2 = iter.next();
+    try std.testing.expect(cp2 == null);
+}
+
+test "string display width" {
+    try internal.init();
+    defer internal.deinit();
+    try std.testing.expectEqual(4, try stringDisplayWidth("\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD", .codepoints));
+    try std.testing.expectEqual(2, try stringDisplayWidth("\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD", .graphemes));
+}

--- a/src/tuile.zig
+++ b/src/tuile.zig
@@ -9,8 +9,6 @@ pub const widgets = @import("widgets.zig");
 pub usingnamespace widgets;
 pub const display = @import("display.zig");
 pub usingnamespace display;
-const grapheme = @import("grapheme");
-const DisplayWidth = @import("DisplayWidth");
 pub const text_clustering = @import("text_clustering.zig");
 
 const Task = widgets.Callback(void);

--- a/src/tuile.zig
+++ b/src/tuile.zig
@@ -11,12 +11,14 @@ pub const display = @import("display.zig");
 pub usingnamespace display;
 const grapheme = @import("grapheme");
 const DisplayWidth = @import("DisplayWidth");
+pub const text_clustering = @import("text_clustering.zig");
 
 const Task = widgets.Callback(void);
 
 // Make it user-driven?
 const FRAMES_PER_SECOND = 30;
 const FRAME_TIME_NS = std.time.ns_per_s / FRAMES_PER_SECOND;
+const GRAPHEME_CLUSTERING_MODE = 2027; // https://mitchellh.com/writing/grapheme-clusters-in-terminals
 
 pub const EventHandler = struct {
     handler: *const fn (payload: ?*anyopaque, event: events.Event) anyerror!events.EventResult,
@@ -54,10 +56,16 @@ pub const Tuile = struct {
     task_queue_mutex: std.Thread.Mutex,
 
     pub fn init(config: Config) !Tuile {
-        try internal.init();
+        const backend = if (config.backend) |backend| backend else try backends.createBackend();
+        errdefer backend.destroy();
+        const text_clustering_type: text_clustering.ClusteringType =
+            switch (try backend.requestMode(GRAPHEME_CLUSTERING_MODE)) {
+            .not_recognized, .reset => .codepoints,
+            .set => .graphemes,
+        };
+
+        try internal.init(text_clustering_type);
         var self = blk: {
-            const backend = if (config.backend) |backend| backend else try backends.createBackend();
-            errdefer backend.destroy();
             const root = try widgets.StackLayout.create(.{ .orientation = .vertical }, .{});
             errdefer root.destroy();
 

--- a/src/widgets/Label.zig
+++ b/src/widgets/Label.zig
@@ -8,7 +8,8 @@ const Frame = @import("../render/Frame.zig");
 const LayoutProperties = @import("LayoutProperties.zig");
 const Constraints = @import("Constraints.zig");
 const display = @import("../display.zig");
-const DisplayWidth = @import("DisplayWidth");
+const text_clustering = @import("../text_clustering.zig");
+const stringDisplayWidth = text_clustering.stringDisplayWidth;
 
 const PartialChunk = struct {
     orig: usize,
@@ -117,13 +118,12 @@ pub fn render(self: *Label, area: Rect, frame: Frame, _: display.Theme) !void {
 pub fn layout(self: *Label, constraints: Constraints) !Vec2 {
     try self.wrapText(constraints);
 
-    const dw = DisplayWidth{ .data = &internal.dwd };
     var max_len: usize = 0;
     for (self.rows.items) |row| {
         var len: usize = 0;
         for (row.chunks.items) |chunk| {
             const text = self.content.getTextForChunk(chunk.orig)[chunk.start..chunk.end];
-            len += dw.strWidth(text);
+            len += try stringDisplayWidth(text, internal.text_clustering_type);
         }
         max_len = @max(max_len, len);
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[x] Feature
```

## Description
<!--- Short description of your changes -->
Query for mode 2027. If it's enabled, render by grapheme clusters, otherwise render by codepoints.

## Related issue
Fixes #10 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- If it's OS-specific (like a backend), include details of your testing environment -->
Tested in Terminal.app and Windows' PowerShell that don't support grapheme clustering, and WezTerm that does support it.